### PR TITLE
[fix] Always trigger `onChange` for valid input

### DIFF
--- a/src/components/date-inputs/index.tsx
+++ b/src/components/date-inputs/index.tsx
@@ -86,7 +86,8 @@ export const DateInputs = ({
       year = show.includes(Unit.year) ? undefined : 2020,
     } = parsedValues;  
 
-    if (isValid(day, month, year) && year.toString().length === 4) {
+    const valuesDefined = [day, month, year].every(value => typeof value !== "undefined");
+    if (valuesDefined && isValid(day, month, year) && year.toString().length === 4) {
       onChange(new Date(year, month - 1, day));
     } else {
       onChange(undefined);

--- a/src/components/date-inputs/index.tsx
+++ b/src/components/date-inputs/index.tsx
@@ -50,6 +50,7 @@ export const DateInputs = ({
   const dayInputRef = useRef<HTMLInputElement>(null);
   const monthInputRef = useRef<HTMLInputElement>(null);
   const yearInputRef = useRef<HTMLInputElement>(null);
+  const isFirstRenderRef = useRef(true);
 
   const refs = {
     [Unit.day]: dayInputRef,
@@ -70,23 +71,25 @@ export const DateInputs = ({
   });
 
   useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+
+    if (!onChange) {
+      return;
+    }
+    
     const {
       day = show.includes(Unit.day) ? undefined : 1,
       month = show.includes(Unit.month) ? undefined : 1,
       year = show.includes(Unit.year) ? undefined : 2020,
-    } = parsedValues;
+    } = parsedValues;  
 
-    const isInitial =
-      day === getDate(value!) && month === getMonth(value!) + 1 && year === getYear(value!);
-
-    if (onChange && !isInitial) {
-      if (day === undefined || month === undefined || year === undefined) {
-        onChange(undefined);
-      } else if (isValid(day, month, year) && year.toString().length === 4) {
-        onChange(new Date(year, month - 1, day));
-      } else {
-        onChange(undefined);
-      }
+    if (isValid(day, month, year) && year.toString().length === 4) {
+      onChange(new Date(year, month - 1, day));
+    } else {
+      onChange(undefined);
     }
   }, [parsedValues, onChange, show, value]);
 


### PR DESCRIPTION
Even if initial value.

- Avoid calling `onChange` on first render
- Reduce cyclomatic complexity
- Simplify `if/else` statement

Fixes #39